### PR TITLE
fix: install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,20 @@ requirements:
 	pip install -e .    # Install this package and its dependencies
 	pip install -r test-requirements.txt
 
+
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements text files based on the requirements/*.in files
-	pip install -q pip-tools
+upgrade: $(COMMON_CONSTRAINTS_TXT)
+	## update the requirements text files based on the requirements/*.in files
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o test-requirements.txt requirements/test.in
 	# Let tox control the Django version for tests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,11 +16,11 @@ charset-normalizer==2.0.12
     # via requests
 click==8.1.3
     # via edx-django-utils
-cryptography==37.0.2
+cryptography==37.0.3
     # via pyjwt
 django==3.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   django-model-utils
@@ -34,7 +34,7 @@ django-model-utils==4.2.0
     # via -r requirements/base.in
 django-simple-history==3.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
 django-waffle==2.5.0
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,5 +9,5 @@
 # linking to it here is good.
 
 # Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
  

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,0 +1,3 @@
+-c constraints.txt
+
+pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
+click==8.1.3
+    # via pip-tools
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.6.2
+    # via -r requirements/pip-tools.in
+tomli==2.0.1
+    # via pep517
 wheel==0.37.1
-    # via -r requirements/pip.in
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
-    # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+# pip
+# setuptools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,7 +42,7 @@ coverage[toml]==6.4.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.3
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -53,7 +53,7 @@ dill==0.3.5.1
 distlib==0.3.4
     # via virtualenv
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   django-crum
     #   django-model-utils
@@ -69,7 +69,7 @@ django-model-utils==4.2.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
 django-waffle==2.5.0
     # via


### PR DESCRIPTION
Added pip-tools requirements file and updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this [PR](https://github.com/https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health.