### PR TITLE
chore: Updating Python Requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ click==8.1.3
     # via edx-django-utils
 cryptography==38.0.1
     # via pyjwt
-django==3.2.15
+django==3.2.17
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in


### PR DESCRIPTION
Updates `django` from `3.2.15` to `3.2.17`