### PR TITLE
fix: organization PUT API AttributeError

### DIFF
--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -25,12 +25,21 @@ class OrganizationSerializer(serializers.ModelSerializer):
             obj.logo.save(logo_url.split('/')[-1], ContentFile(logo.content))
 
     def create(self, validated_data):
+        """
+        New organizations created through the API are always Active
+        """
+        validated_data.update({'active': True})
         logo_url = validated_data.pop('logo_url', None)
         obj = super().create(validated_data)
         self.update_logo(obj, logo_url)
         return obj
 
     def update(self, instance, validated_data):
+        """
+        Existing organizations updated through the API always end up Active,
+        regardless of whether or not they were previously active
+        """
+        validated_data.update({'active': True})
         logo_url = validated_data.pop('logo_url', None)
         super().update(instance, validated_data)
         self.update_logo(instance, logo_url)

--- a/organizations/v0/views.py
+++ b/organizations/v0/views.py
@@ -60,7 +60,6 @@ class OrganizationsViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
             raise ValidationError(
                 "Value of 'active' may not be specified via Organizations HTTP API."
             )
-        self.request.data['active'] = True
         try:
             return super().update(request, *args, **kwargs)
         except Http404:


### PR DESCRIPTION
This fixes #409.
```
self.request.data['active'] = True
```
`self.request.data` is QueryDict hence it is immutable so we can not add `active: True`.

With this PR, `active: True` is added on the serializer side.