### PR TITLE
drop python3.8 from support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-24.04]
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
         toxenv: [django42, quality]
 
     steps:
@@ -36,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='django42'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django42'
       uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ _____
 
 * Added the changelog file
 
+Removed
+_____
+
+* Dropped support for python 3.8
+
 
 [v6.13.0] - 2024-04-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311,312}-django{42}, quality
+envlist = py{311,312}-django{42}, quality
 
 [testenv]
 setenv = 


### PR DESCRIPTION
This PR is investigating if I can solve the issues with the update bot by dropping support for 3.8 now that redwood is cut.

https://openedx.atlassian.net/wiki/spaces/COMM/pages/4160847886/2024-04-11+Meeting+notes

From #415:

- [x] Update the `tox.ini`, `setup.py`, `setup.cfg`, or `pyproject.toml` to remove Python 3.8 from the supported versions list.
- [x] Ensure the GitHub Actions workflows are updated, particularly removing Python 3.8 from the CI matrix.
- [ ] Review and clean up any testing or build configurations referencing Python versions earlier than 3.11.
- [x] Run tests in the CI to ensure everything passes after removing Python 3.8.
- [x] Add a CHANGELOG entry: “Dropped support for Python 3.8.”
- [ ] Bump the package version and release a new version on GitHub & PyPI (if applicable).
