### PR TITLE
docs: Add PII annotations

### DIFF
--- a/organizations/models.py
+++ b/organizations/models.py
@@ -17,6 +17,8 @@ class Organization(TimeStampedModel):
     An Organization is a representation of an entity which publishes/provides
     one or more courses delivered by the LMS. Organizations have a base set of
     metadata describing the organization, including id, name, and description.
+
+    .. no_pii:
     """
     name = models.CharField(max_length=255, db_index=True)
     short_name = models.CharField(
@@ -55,6 +57,8 @@ class OrganizationCourse(TimeStampedModel):
     Course (via course key). Because Courses are not true Open edX entities
     (in the Django/ORM sense) the modeling and integrity is limited to that
     of specifying course identifier strings in this model.
+
+    .. no_pii:
     """
     course_id = models.CharField(max_length=255, db_index=True, verbose_name='Course ID')
     organization = models.ForeignKey(Organization, db_index=True, on_delete=models.CASCADE)


### PR DESCRIPTION
Per OEP-30, PII annotations should live with their models. This is just moving these annotations from the edx-platform safe list to their appropriate home.